### PR TITLE
Command to rename all ArXiv files to canonical format

### DIFF
--- a/tk/dbox/provider/arxiv.py
+++ b/tk/dbox/provider/arxiv.py
@@ -56,7 +56,7 @@ def pdfurl(id_or_url: str) -> str:
 
 
 def maybe_id(s: str) -> bool:  # TODO improve+test this
-  return re.match(r'\d{4}\.\d{5}', s.removesuffix('.pdf').strip('[]'))
+  return re.search(r'^\d{4}\.\d{5}$', s.removesuffix('.pdf').strip('[]'))
 
 
 def go(getter: ty.Callable[[str], str], id_or_url: str):


### PR DESCRIPTION
Looks over all files and renames them using the `mv` command.
Hacky sol'n to list all files from endpoint but eh.
Fix some other time.